### PR TITLE
Give absolute path to MELADIR

### DIFF
--- a/MELA/makefile
+++ b/MELA/makefile
@@ -14,7 +14,7 @@ else
 
 RM  = /bin/rm
 
-MELADIR = .
+MELADIR = $(shell pwd)
 MELASRCDIR = $(MELADIR)/src
 MELADATADIR = $(MELADIR)/data
 # Modify MELALIBDIR for the gcc version as needed


### PR DESCRIPTION
Since [`MELADIR`](https://github.com/JHUGen/JHUGenMELA/blob/337b23cd9453f20672528e07b6aea7e167a14938/MELA/makefile#L17) variable contains a relative path to the [`MELA`](https://github.com/JHUGen/JHUGenMELA/tree/337b23cd9453f20672528e07b6aea7e167a14938/MELA) directory if one tries to link directly against the `libJHEGenMELAMELA.so` library, the linker fails when tries to search for dependencies of `libJHEGenMELAMELA.so` as they cannot be found within `RPATH` of the `libJHEGenMELAMELA.so` library.

This MR will fix the issue by assigning the `MELADIR` to the absolute path of `MELA` directory.