### PR TITLE
Allow using collier provided externally

### DIFF
--- a/MELA/COLLIER/setup.sh
+++ b/MELA/COLLIER/setup.sh
@@ -35,17 +35,24 @@ if [[ $# > 0 ]] && [[ "$1" == *"clean"* ]]; then
 else
 
   if [[ ! -f "../data/$SCRAM_ARCH/$libname" ]]; then
-    rm -rf $tmpdir
-    rm -f $tarname
-    wget --no-check-certificate $tarweb
-    mkdir $tmpdir
-    tar -xvzf $tarname -C $tmpdir
-    rm -f $tarname
-    mv $tmpdir"/"$pkgdir"/src/"* ./
-    rm -rf $tmpdir
+    if [[ -z "${COLLIER_ROOT_DIR+x}" ]]; then
+      # Build a copy of collier in place
+      rm -rf $tmpdir
+      rm -f $tarname
+      wget --no-check-certificate $tarweb
+      mkdir $tmpdir
+      tar -xvzf $tarname -C $tmpdir
+      rm -f $tarname
+      mv $tmpdir"/"$pkgdir"/src/"* ./
+      rm -rf $tmpdir
 
-    make $@
-    mv $libname "../data/$SCRAM_ARCH/$libname"
+      make $@
+      mv $libname "../data/$SCRAM_ARCH/$libname"
+    else
+      # Will use collier provided externally. Link the library at the location
+      # expected by test/loadMELA.C.
+      ln -s "$COLLIER_ROOT_DIR/lib/$libname" "../data/$SCRAM_ARCH/$libname"
+    fi
   fi
 
 fi

--- a/MELA/fortran/makefile
+++ b/MELA/fortran/makefile
@@ -30,12 +30,14 @@ endif
 
 # Linking the Collier library
 UseCOLLIER=Yes
-# directory which contains libLHAPDF.a, libLHAPDF.la, libLHAPDF.so
-MyCOLLIERDir=../data/${SCRAM_ARCH}/
-MyCOLLIERInc=../COLLIER/
-# remember to export
-#          LD_LIBRARY_PATH=/.../LHAPDF-x.y.z/lib/:${LD_LIBRARY_PATH}
-#          LHAPDF_DATA_PATH=/.../LHAPDF-x.y.z/share/LHAPDF/:${LHAPDF_DATA_PATH}
+ifeq ($(COLLIER_ROOT_DIR),)
+   MyCOLLIERDir=../data/${SCRAM_ARCH}/
+   MyCOLLIERInc=../COLLIER/
+else
+   # Use collier provided externally
+   MyCOLLIERDir=$(COLLIER_ROOT_DIR)/lib
+   MyCOLLIERInc=$(COLLIER_ROOT_DIR)/include
+endif
 ifeq ($(UseCOLLIER),Yes)
    COLLIERflags = -L$(MyCOLLIERDir) -lcollier -DuseCollier=1 -I$(MyCOLLIERInc)
 else


### PR DESCRIPTION
`collier` (version 1.2.4) is [available](http://lcginfo.cern.ch/pkg/collier/) in LCG software stacks&dagger;, so there is no need to build it if this environment is used. This commit will skip the build of `collier` if environmental variable `COLLIER_ROOT_DIR` is set. In that case the rest of `JHUGenMELA` will assume that the interface modules and the shared library of `collier` are located within directories `$COLLIER_ROOT_DIR/include` and `$COLLIER_ROOT_DIR/lib` respectively. If this variable is not set, `collier` will be built in place as before.

Skipping compilation of `collier` reduces the total build time (run in one thread) from 470 to 310 s.

I checked that the package compiles both when `COLLIER_ROOT_DIR` is set and not set. After building with `COLLIER_ROOT_DIR`, all tests in `test/testME_all.py` succeed.

&dagger;This works with `LCG_97a` and later. `collier` was included also in earlier releases, but they missed `collier.mod` interface module.
