### PR TITLE
Fix standalone compilation under gcc 10.x

### DIFF
--- a/MELA/.gitignore
+++ b/MELA/.gitignore
@@ -1,3 +1,4 @@
 obj
 lib
 executables
+**/TEMP

--- a/MELA/data/slc7_amd64_gcc10/download.url
+++ b/MELA/data/slc7_amd64_gcc10/download.url
@@ -1,0 +1,1 @@
+http://spin.pha.jhu.edu/Generator/MCFM-precompiled/v7_920/

--- a/MELA/interface/MELANCSplineCore.h
+++ b/MELA/interface/MELANCSplineCore.h
@@ -8,6 +8,7 @@
 #include "RooAbsReal.h"
 #include "RooRealVar.h"
 #include "RooRealProxy.h"
+#include "RooListProxy.h"
 #include "RooConstVar.h"
 #include "RooArgList.h"
 #include "RooMsgService.h"

--- a/MELA/setup.sh
+++ b/MELA/setup.sh
@@ -3,6 +3,25 @@
 (
 set -euo pipefail
 
+
+getSCRAMVERSION(){
+  GCCVERSION=$(gcc -dumpversion)
+  if [[ "$GCCVERSION" == "4.3"* ]] || [[ "$GCCVERSION" == "4.4"* ]] || [[ "$GCCVERSION" == "4.5"* ]]; then # v1 of MCFM library
+    echo slc5_amd64_gcc434
+  elif [[ "$GCCVERSION" == "4"* ]] || [[ "$GCCVERSION" == "5"* ]] || [[ "$GCCVERSION" == "6"* ]]; then # v2 of MCFM library
+    echo slc6_amd64_gcc630
+  elif [[ "$GCCVERSION" == "7"* ]]; then # v3 of MCFM library
+    echo slc7_amd64_gcc700
+  elif [[ "$GCCVERSION" == "8.0"* ]] || [[ "$GCCVERSION" == "8.1"* ]] || [[ "$GCCVERSION" == "8.2"* ]]; then # v4 of MCFM library
+    echo slc7_amd64_gcc820
+  elif [[ "$GCCVERSION" == "8"* ]]; then # v4 of MCFM library
+    echo slc6_amd64_gcc830
+  else
+    echo slc7_amd64_gcc920
+  fi
+}
+
+
 cd $(dirname ${BASH_SOURCE[0]})
 
 MELADIR="$(readlink -f .)"
@@ -33,6 +52,8 @@ done
 declare -i nSetupArgs
 nSetupArgs=${#setupArgs[@]}
 
+SARCH=$(getSCRAMVERSION)
+
 if [[ ${forceStandalone} -eq 0 ]] && [[ ! -z "${CMSSW_BASE+x}" ]]; then
 
   usingCMSSW=1
@@ -44,20 +65,7 @@ else
   if [[ -z "${SCRAM_ARCH+x}" ]]; then
     needSCRAM=1
 
-    GCCVERSION=$(gcc -dumpversion)
-    if [[ "$GCCVERSION" == "4.3"* ]] || [[ "$GCCVERSION" == "4.4"* ]] || [[ "$GCCVERSION" == "4.5"* ]]; then # v1 of MCFM library
-      export SCRAM_ARCH="slc5_amd64_gcc434"
-    elif [[ "$GCCVERSION" == "4"* ]] || [[ "$GCCVERSION" == "5"* ]] || [[ "$GCCVERSION" == "6"* ]]; then # v2 of MCFM library
-      export SCRAM_ARCH="slc6_amd64_gcc630"
-    elif [[ "$GCCVERSION" == "7"* ]]; then # v3 of MCFM library
-      export SCRAM_ARCH="slc7_amd64_gcc700"
-    elif [[ "$GCCVERSION" == "8.0"* ]] || [[ "$GCCVERSION" == "8.1"* ]] || [[ "$GCCVERSION" == "8.2"* ]]; then # v4 of MCFM library
-      export SCRAM_ARCH="slc7_amd64_gcc820"
-    elif [[ "$GCCVERSION" == "8"* ]]; then # v4 of MCFM library
-      export SCRAM_ARCH="slc6_amd64_gcc830"
-    else
-      export SCRAM_ARCH="slc7_amd64_gcc920"
-    fi
+    export SCRAM_ARCH="${SARCH}"
   fi
 
 fi
@@ -172,9 +180,7 @@ fi
 
 
 if [[ $doDeps -eq 1 ]]; then
-    doenv
-    dodeps
-    exit
+    : ok
 elif [[ "$nSetupArgs" -eq 1 ]] && [[ "${setupArgs[0]}" == *"clean"* ]]; then
     #echo "Cleaning C++"
     if [[ ${usingCMSSW} -eq 1 ]];then
@@ -192,6 +198,10 @@ elif [[ "$nSetupArgs" -eq 1 ]] && [[ "${setupArgs[0]}" == *"clean"* ]]; then
     #echo "Cleaning COLLIER"
     ${MELADIR}/COLLIER/setup.sh "${setupArgs[@]}"
 
+    if [[ -e data/${SCRAM_ARCH}/TEMP ]]; then
+      rm -rf data/${SCRAM_ARCH}
+    fi
+
     exit
 elif [[ "$nSetupArgs" -ge 1 ]] && [[ "$nSetupArgs" -le 2 ]] && [[ "${setupArgs[0]}" == *"-j"* ]]; then
     : ok
@@ -202,8 +212,17 @@ else
     exit 1
 fi
 
+
+if [[ ! -d data/${SCRAM_ARCH} ]]; then
+  cp -r data/${SARCH} data/${SCRAM_ARCH}
+  touch data/${SCRAM_ARCH}/TEMP
+fi
 doenv
 dodeps
+if [[ $doDeps -eq 1 ]]; then
+    exit
+fi
+
 pushd ${MELADIR}/fortran
 make "${setupArgs[@]}"
 if mv libjhugenmela.so ../data/${SCRAM_ARCH}/; then


### PR DESCRIPTION
Opened per request of CMS colleagues, this PR fixes compilation issues with gcc versions 10.x (partially fixing compilation under CMSSW 12.x.y).

Only the standalone part is fixed as there are some ROOT dictionary compilation issues related to CMSSW 12.x.y. These issues do not appear in standalone compilation, so they are deemed as CMS software bugs at the moment. A later PR could be issued to fix specific issues if CMSSW-type compilation needs any fixes, but it is unnecessary at the moment.