### PR TITLE
Fixed 13.6 -> 14 TeV rounding error

### DIFF
--- a/MELA/src/SuperDijetMela.cc
+++ b/MELA/src/SuperDijetMela.cc
@@ -35,8 +35,9 @@ void SuperDijetMela::Build(){
 void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
   // Setup file path
   const string MELAPKGPATH = TVar::GetMELAPath();
+  double intpart;
   TString path = TString(MELAPKGPATH.c_str()) + "data/resolution_mJJ_recoVStrue_";
-  TString prodName;
+  TString prodName, floatflag;
   switch (prod){
   case TVar::Had_ZH:
     prodName = "ZH";
@@ -48,10 +49,12 @@ void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
     MELAout << "SuperDijetMela::SetupResolutionModel: Production " << TVar::ProductionName(prod) << " is unknown." << endl;
     return;
   }
+  if (modf(sqrts, &intpart) == 0.0) floatflag = "%.0f"; else floatflag = "%.1f";
+  
   path += prodName;
-  path += Form("_%.0fTeV%s", sqrts, ".root");
+  path += Form("_"+floatflag+"TeV%s", sqrts, ".root");
 
-  TString appendName = Form("mJJReso_%.0fTeV", sqrts);
+  TString appendName = Form("mJJReso_"+floatflag+"TeV", sqrts);
   MELADifermionResolutionModel* model = new MELADifermionResolutionModel(prod, sqrts, path, appendName);
   if (model->isValid()){
     int iprod = (int)prod;


### PR DESCRIPTION
Fixed issue where using sqrts=13.6 would result in filenames with 14TeV, due to a rounding error in the way doubles were parsed into strings for the file path