### PR TITLE
Fixed 13.6 -> 14 TeV rounding error (interim)

### DIFF
--- a/MELA/src/SuperDijetMela.cc
+++ b/MELA/src/SuperDijetMela.cc
@@ -35,6 +35,7 @@ void SuperDijetMela::Build(){
 void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
   // Setup file path
   const string MELAPKGPATH = TVar::GetMELAPath();
+  double intpart;
   TString path = TString(MELAPKGPATH.c_str()) + "data/resolution_mJJ_recoVStrue_";
   TString prodName;
   switch (prod){
@@ -48,10 +49,12 @@ void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
     MELAout << "SuperDijetMela::SetupResolutionModel: Production " << TVar::ProductionName(prod) << " is unknown." << endl;
     return;
   }
+  if (modf(sqrts, &intpart) == 0.0) floatflag = "%.0f"; else floatflag = "%.1f";
+  
   path += prodName;
-  path += Form("_%.0fTeV%s", sqrts, ".root");
+  path += Form("_"+floatflag+"TeV%s", sqrts, ".root");
 
-  TString appendName = Form("mJJReso_%.0fTeV", sqrts);
+  TString appendName = Form("mJJReso_"+floatflag+"TeV", sqrts);
   MELADifermionResolutionModel* model = new MELADifermionResolutionModel(prod, sqrts, path, appendName);
   if (model->isValid()){
     int iprod = (int)prod;

--- a/MELA/src/SuperDijetMela.cc
+++ b/MELA/src/SuperDijetMela.cc
@@ -35,10 +35,8 @@ void SuperDijetMela::Build(){
 void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
   // Setup file path
   const string MELAPKGPATH = TVar::GetMELAPath();
-  double intpart;
-  bool floatFloor = false; // In case production is not ready, set this to true
   TString path = TString(MELAPKGPATH.c_str()) + "data/resolution_mJJ_recoVStrue_";
-  TString prodName, floatflag;
+  TString prodName;
   switch (prod){
   case TVar::Had_ZH:
     prodName = "ZH";
@@ -50,13 +48,12 @@ void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
     MELAout << "SuperDijetMela::SetupResolutionModel: Production " << TVar::ProductionName(prod) << " is unknown." << endl;
     return;
   }
-  if (floatFloor) sqrts = floor(sqrts);
-  if (modf(sqrts, &intpart) == 0.0) floatflag = "%.0f"; else floatflag = "%.1f";
+  sqrts = floor(sqrts); // interim solution until 13.6 TeV production is ready
   
   path += prodName;
-  path += Form("_"+floatflag+"TeV%s", sqrts, ".root");
+  path += Form("_%.0fTeV%s", sqrts, ".root");
 
-  TString appendName = Form("mJJReso_"+floatflag+"TeV", sqrts);
+  TString appendName = Form("mJJReso_%.0fTeV", sqrts);
   MELADifermionResolutionModel* model = new MELADifermionResolutionModel(prod, sqrts, path, appendName);
   if (model->isValid()){
     int iprod = (int)prod;

--- a/MELA/src/SuperDijetMela.cc
+++ b/MELA/src/SuperDijetMela.cc
@@ -36,8 +36,9 @@ void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
   // Setup file path
   const string MELAPKGPATH = TVar::GetMELAPath();
   double intpart;
+  bool floatFloor = false; // In case production is not ready, set this to true
   TString path = TString(MELAPKGPATH.c_str()) + "data/resolution_mJJ_recoVStrue_";
-  TString prodName;
+  TString prodName, floatflag;
   switch (prod){
   case TVar::Had_ZH:
     prodName = "ZH";
@@ -49,6 +50,7 @@ void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
     MELAout << "SuperDijetMela::SetupResolutionModel: Production " << TVar::ProductionName(prod) << " is unknown." << endl;
     return;
   }
+  if (floatFloor) sqrts = floor(sqrts);
   if (modf(sqrts, &intpart) == 0.0) floatflag = "%.0f"; else floatflag = "%.1f";
   
   path += prodName;


### PR DESCRIPTION
Fixed issue where using sqrts=13.6 would result in filenames with 14TeV, due to a rounding error in the way doubles were parsed into strings for the file path