### PR TITLE
Added Anomalous Zff Couplings Interface to JHUGen & MCFM (C)

### DIFF
--- a/MELA/interface/Mela.h
+++ b/MELA/interface/Mela.h
@@ -212,6 +212,7 @@ public:
     double selfDHvvcoupl_input[nSupportedHiggses][SIZE_HVV][2],
     double selfDHwwcoupl_input[nSupportedHiggses][SIZE_HVV][2],
     double selfDaTQGCcoupl_input[SIZE_ATQGC][2],
+    double selfDAZffcoupl_input[SIZE_AZff][2],
     float& prob,
     bool useConstant=true
     );
@@ -341,6 +342,8 @@ public:
   double selfDGvpvpcoupl[SIZE_GVV][2];
   //****aTQGC****//
   double selfDaTQGCcoupl[SIZE_ATQGC][2];
+  //****Anomnalous Zff**//
+  double selfDAZffcoupl[SIZE_AZff][2];
   // That is a lot of them!
 
   static void cleanLinkedFiles();
@@ -434,6 +437,7 @@ protected:
   void setSpinOneCouplings();
   void setSpinTwoCouplings();
   void setATQGCCouplings();
+  void setAZffCouplings();
 
   bool configureAnalyticalPDFs();
   void reset_SelfDCouplings();

--- a/MELA/interface/TCouplings.hh
+++ b/MELA/interface/TCouplings.hh
@@ -140,4 +140,19 @@ public:
   double aTQGCcoupl[SIZE_ATQGC][2];
 };
 
+class AZffCouplings{
+public:
+  AZffCouplings();
+  AZffCouplings(AZffCouplings const& other);
+  virtual ~AZffCouplings();
+
+  void reset();
+  void copy(AZffCouplings const& other);
+  AZffCouplings* getRef();
+
+  void SetAZffCouplings(unsigned int index, double c_real, double c_imag);
+
+  double AZffcoupl[SIZE_AZff][2];
+};
+
 #endif

--- a/MELA/interface/TCouplingsBase.hh
+++ b/MELA/interface/TCouplingsBase.hh
@@ -180,6 +180,25 @@ namespace{
 
     SIZE_ATQGC
   };
+  enum{
+  // Decay
+    gZllRH, //reZ
+    gZllLH, //leZ
+    gZuuRH, //rquZ
+    gZuuLH, //lquZ
+    gZddRH, //rqdZ
+    gZddLH, //lqdZ
+    gZnunuRH, //rnZ
+    gZnunuLH, //lnZ
+
+  // Production
+    guZRH, //cranou
+    guZLH, //clanou
+    gdZRH, //cranod
+    gdZLH, //clanod
+
+    SIZE_AZff
+  };
 }
 
 

--- a/MELA/interface/TEvtProb.hh
+++ b/MELA/interface/TEvtProb.hh
@@ -121,6 +121,7 @@ public:
   SpinTwoCouplings* GetSelfDSpinTwoCouplings();
   VprimeCouplings* GetSelfDVprimeCouplings();
   aTQGCCouplings* GetSelfDaTQGCCouplings();
+  AZffCouplings* GetSelfDAZffCouplings();
   double GetPrimaryHiggsMass();
   double GetPrimaryMass(int ipart);
   double GetPrimaryWidth(int ipart);
@@ -156,6 +157,7 @@ protected:
   SpinTwoCouplings selfDSpinTwoCoupl;
   VprimeCouplings selfDVprimeCoupl;
   aTQGCCouplings selfDaTQGCCoupl;
+  AZffCouplings selfDAZffCoupl;
   MelaIO RcdME;
 
   MELACandidate* melaCand; // Only a pointer to the top-level (input) candList object
@@ -179,6 +181,7 @@ protected:
   bool CheckSelfDCouplings_Hbb();
   bool CheckSelfDCouplings_HVV();
   bool CheckSelfDCouplings_aTQGC();
+  bool CheckSelfDCouplings_AZff();
 
   // Constructor wrapper
   void Build();

--- a/MELA/interface/TMCFM.hh
+++ b/MELA/interface/TMCFM.hh
@@ -248,16 +248,16 @@ extern "C" {
     int AllowAnomalousZffCouplings;
     double reZ;
     double leZ;
-    double rnZ;
     double lnZ;
-    double clanou;
-    double cranou;
-    double clanod;
-    double cranod;
+    double rnZ;
     double rquZ;
     double lquZ;
     double rqdZ;
     double lqdZ;
+    double clanou;
+    double cranou;
+    double clanod;
+    double cranod;
   } anomzffcouplings_;
 
   extern struct {

--- a/MELA/interface/TMCFM.hh
+++ b/MELA/interface/TMCFM.hh
@@ -245,6 +245,22 @@ extern "C" {
   } spinzerohiggs_anomcoupl_;
 
   extern struct {
+    int AllowAnomalousZffCouplings;
+    double reZ;
+    double leZ;
+    double rnZ;
+    double lnZ;
+    double clanou;
+    double cranou;
+    double clanod;
+    double cranod;
+    double rquZ;
+    double lquZ;
+    double rqdZ;
+    double lqdZ;
+  } anomzffcouplings_;
+
+  extern struct {
     bool srdiags;
   } srdiags_;
 

--- a/MELA/interface/TUtil.hh
+++ b/MELA/interface/TUtil.hh
@@ -244,6 +244,8 @@ namespace TUtil{
   void SetJHUGenSpinTwoCouplings(double Gacoupl[SIZE_GGG][2], double Gvvcoupl[SIZE_GVV][2], double Gvvpcoupl[SIZE_GVV][2], double Gvpvpcoupl[SIZE_GVV][2], double qLeftRightcoupl[SIZE_GQQ][2]);
   // Vprime / contact couplings
   void SetJHUGenVprimeContactCouplings(double Zpffcoupl[SIZE_Vpff][2], double Wpffcoupl[SIZE_Vpff][2]);
+  // AZff
+  void SetMCFMAZffCouplings(bool useBSM, AZffCouplings const* Zcouplings);
 
   // PS cuts, unused
   bool MCFM_masscuts(double s[][mxpart], const TVar::Process& process);

--- a/MELA/interface/ZZMatrixElement.h
+++ b/MELA/interface/ZZMatrixElement.h
@@ -128,6 +128,9 @@ public:
   void set_aTQGCCouplings(
     double selfDaTQGCcoupl[SIZE_ATQGC][2]
   );
+  void set_AZffCouplings(
+    double selfDAZffcoupl[SIZE_AZff][2]
+  );
 
   // Compute four-momenta from angles - not cos(theta) - only 
   std::vector<TLorentzVector> Calculate4Momentum(double Mx, double M1, double M2, double theta, double theta1, double theta2, double Phi1, double Phi);
@@ -161,6 +164,7 @@ protected:
   SpinTwoCouplings* selfD_SpinTwoCouplings;
   VprimeCouplings* selfD_VprimeCouplings;
   aTQGCCouplings* selfD_aTQGCCouplings;
+  AZffCouplings* selfD_AZffCouplings;
 
   MELACandidate* melaCand; // Pointer to current candidate object of Xcal2
   std::vector<MELAParticle*> tmpPartList; // Vector of pointers to the owned, temporary MELAParticles

--- a/MELA/src/Mela.cc
+++ b/MELA/src/Mela.cc
@@ -372,6 +372,11 @@ void Mela::setATQGCCouplings(){
     selfDaTQGCcoupl
   );
 }
+void Mela::setAZffCouplings(){
+  ZZME->set_AZffCouplings(
+    selfDAZffcoupl
+  );
+}
 
 
 // Notice that this only sets the members of MELA, not TEvtProb. TEvtProb resets itself.
@@ -448,6 +453,11 @@ void Mela::reset_SelfDCouplings(){
   // aTQGC couplings
   for (int im=0; im<2; im++){
     for (int ic=0; ic<SIZE_ATQGC; ic++) selfDaTQGCcoupl[ic][im] = 0;
+  }
+
+  // AZff couplings
+  for (int im=0; im<2; im++){
+    for (int ic=0; ic<SIZE_AZff; ic++) selfDAZffcoupl[ic][im] = 0;
   }
 
   // Did I tell you that we have a lot of them?
@@ -1170,7 +1180,7 @@ void Mela::computeP(
     }
     else if (myME_ == TVar::JHUGen || myME_ == TVar::MCFM){
       if (!(myME_ == TVar::MCFM  && myProduction_ == TVar::ZZINDEPENDENT &&  (myModel_ == TVar::bkgZZ || myModel_ == TVar::bkgWW || myModel_ == TVar::bkgZGamma || myModel_ == TVar::bkgGammaGamma))){
-        if (myME_ == TVar::MCFM || myModel_ == TVar::SelfDefine_spin0) setSpinZeroCouplings();
+        if (myME_ == TVar::MCFM || myModel_ == TVar::SelfDefine_spin0) { setSpinZeroCouplings(); setAZffCouplings(); }
         else if (myModel_ == TVar::SelfDefine_spin1) setSpinOneCouplings();
         else if (myModel_ == TVar::SelfDefine_spin2) setSpinTwoCouplings();
         ZZME->computeXS(prob);
@@ -1377,6 +1387,7 @@ void Mela::computeProdDecP(
   double selfDHvvcoupl_input[nSupportedHiggses][SIZE_HVV][2],
   double selfDHwwcoupl_input[nSupportedHiggses][SIZE_HVV][2],
   double selfDaTQGCcoupl_input[SIZE_ATQGC][2],
+  double selfDAZffcoupl_input[SIZE_AZff][2],
   float& prob,
   bool useConstant
   ){
@@ -1390,6 +1401,9 @@ void Mela::computeProdDecP(
   }
   for (int im=0; im<2; im++){
     for (int ic=0; ic<SIZE_ATQGC; ic++) selfDaTQGCcoupl[ic][im] = selfDaTQGCcoupl_input[ic][im];
+  }
+  for (int im=0; im<2; im++){
+    for (int ic=0; ic<SIZE_AZff; ic++) selfDAZffcoupl[ic][im] = selfDAZffcoupl_input[ic][im];
   }
   computeProdDecP(
     prob,

--- a/MELA/src/SuperDijetMela.cc
+++ b/MELA/src/SuperDijetMela.cc
@@ -35,8 +35,9 @@ void SuperDijetMela::Build(){
 void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
   // Setup file path
   const string MELAPKGPATH = TVar::GetMELAPath();
+  double intpart;
   TString path = TString(MELAPKGPATH.c_str()) + "data/resolution_mJJ_recoVStrue_";
-  TString prodName;
+  TString prodName, floatflag;
   switch (prod){
   case TVar::Had_ZH:
     prodName = "ZH";
@@ -48,10 +49,12 @@ void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
     MELAout << "SuperDijetMela::SetupResolutionModel: Production " << TVar::ProductionName(prod) << " is unknown." << endl;
     return;
   }
-  path += prodName;
-  path += Form("_%.0fTeV%s", sqrts, ".root");
+  if (modf(sqrts, &intpart) == 0.0) floatflag = "%.0f"; else floatflag = "%.1f";
 
-  TString appendName = Form("mJJReso_%.0fTeV", sqrts);
+  path += prodName;
+  path += Form("_"+floatflag+"TeV%s", sqrts, ".root");
+
+  TString appendName = Form("mJJReso_"+floatflag+"TeV", sqrts);
   MELADifermionResolutionModel* model = new MELADifermionResolutionModel(prod, sqrts, path, appendName);
   if (model->isValid()){
     int iprod = (int)prod;

--- a/MELA/src/SuperDijetMela.cc
+++ b/MELA/src/SuperDijetMela.cc
@@ -49,7 +49,7 @@ void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
     return;
   }
   sqrts = floor(sqrts); // interim solution until 13.6 TeV production is ready
-
+  
   path += prodName;
   path += Form("_%.0fTeV%s", sqrts, ".root");
 

--- a/MELA/src/SuperDijetMela.cc
+++ b/MELA/src/SuperDijetMela.cc
@@ -35,9 +35,8 @@ void SuperDijetMela::Build(){
 void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
   // Setup file path
   const string MELAPKGPATH = TVar::GetMELAPath();
-  double intpart;
   TString path = TString(MELAPKGPATH.c_str()) + "data/resolution_mJJ_recoVStrue_";
-  TString prodName, floatflag;
+  TString prodName;
   switch (prod){
   case TVar::Had_ZH:
     prodName = "ZH";
@@ -49,13 +48,12 @@ void SuperDijetMela::SetupResolutionModel(TVar::Production prod){
     MELAout << "SuperDijetMela::SetupResolutionModel: Production " << TVar::ProductionName(prod) << " is unknown." << endl;
     return;
   }
-
   sqrts = floor(sqrts); // interim solution until 13.6 TeV production is ready
 
   path += prodName;
-  path += Form("_"+floatflag+"TeV%s", sqrts, ".root");
+  path += Form("_%.0fTeV%s", sqrts, ".root");
 
-  TString appendName = Form("mJJReso_"+floatflag+"TeV", sqrts);
+  TString appendName = Form("mJJReso_%.0fTeV", sqrts);
   MELADifermionResolutionModel* model = new MELADifermionResolutionModel(prod, sqrts, path, appendName);
   if (model->isValid()){
     int iprod = (int)prod;

--- a/MELA/src/TCouplings.cc
+++ b/MELA/src/TCouplings.cc
@@ -459,3 +459,28 @@ void aTQGCCouplings::SetATQGCCouplings(unsigned int index, double c_real, double
     aTQGCcoupl[index][1] = c_imag;
   }
 }
+
+/********** AZff couplings **********/
+AZffCouplings::AZffCouplings(){ reset(); }
+AZffCouplings::AZffCouplings(AZffCouplings const& other){ this->copy(other); }
+AZffCouplings::~AZffCouplings(){}
+
+void AZffCouplings::reset(){
+  for (int im=0; im<2; im++){
+    for (int ic = 0; ic < SIZE_AZff; ic++) AZffcoupl[ic][im]=0;
+  }
+}
+void AZffCouplings::copy(AZffCouplings const& other){
+  for (int im=0; im<2; im++){
+    for (int ic=0; ic<SIZE_AZff; ic++) AZffcoupl[ic][im] = (other.AZffcoupl)[ic][im];
+  }
+}
+AZffCouplings* AZffCouplings::getRef(){ return this; }
+
+void AZffCouplings::SetAZffCouplings(unsigned int index, double c_real, double c_imag){
+  if (index>=SIZE_AZff){ MELAerr << "AZffCouplings::SetAZffCouplings: Cannot set index " << index << ", out of range for the type requested." << endl; }
+  else{
+    AZffcoupl[index][0] = c_real;
+    AZffcoupl[index][1] = c_imag;
+  }
+}

--- a/MELA/src/TUtil.cc
+++ b/MELA/src/TUtil.cc
@@ -2901,6 +2901,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
           strplabel[2]=TUtil::GetMCFMParticleLabel(pId[pZOrder[0]], false, useQQVVQQany);
           strplabel[3]=TUtil::GetMCFMParticleLabel(pId[pZOrder[1]], false, useQQVVQQany);
         }
+        else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+          strplabel[2]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+          strplabel[3]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+        }
         // End special Z1->ll cases
       }
       else if (PDGHelpers::isANeutrino(pId[pZOrder[0]]) && PDGHelpers::isANeutrino(pId[pZOrder[1]])){
@@ -2918,6 +2922,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
         else if (useQQVVQQany){
           strplabel[2]=TUtil::GetMCFMParticleLabel(pId[pZOrder[0]], false, useQQVVQQany);
           strplabel[3]=TUtil::GetMCFMParticleLabel(pId[pZOrder[1]], false, useQQVVQQany);
+        }
+        else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+          strplabel[2]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+          strplabel[3]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
         }
         // End special Z1->nn cases
       }
@@ -2940,6 +2948,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
           else if (useQQVVQQany){
             strplabel[2]=TUtil::GetMCFMParticleLabel(pId[pZOrder[0]], false, useQQVVQQany);
             strplabel[3]=TUtil::GetMCFMParticleLabel(pId[pZOrder[1]], false, useQQVVQQany);
+          }
+          else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+            strplabel[2]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+            strplabel[3]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
           }
         }
         else{
@@ -2971,6 +2983,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
             strplabel[2]="qj";
             strplabel[3]="qj";
           }
+          else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+            strplabel[2]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+            strplabel[3]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+          }
         }
         if (!useQQVVQQany){ // colfac34_56 handles all couplings instead of this simple scaling (Reason: WW final states)
           zcouple_.l1 *= sqrt(3.);
@@ -2982,6 +2998,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
     else if (useQQVVQQany){
       strplabel[2]=TUtil::GetMCFMParticleLabel(pId[pZOrder[0]], false, useQQVVQQany);
       strplabel[3]=TUtil::GetMCFMParticleLabel(pId[pZOrder[1]], false, useQQVVQQany);
+    }
+    else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+      strplabel[2]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+      strplabel[3]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
     }
 
     // Couplings for Z2
@@ -3002,6 +3022,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
           strplabel[4]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, useQQVVQQany);
           strplabel[5]=TUtil::GetMCFMParticleLabel(pId[pZOrder[3]], false, useQQVVQQany);
         }
+        else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+          strplabel[4]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+          strplabel[5]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+        }
         // End special Z2->ll cases
       }
       else if (PDGHelpers::isANeutrino(pId[pZOrder[2]]) && PDGHelpers::isANeutrino(pId[pZOrder[3]])){
@@ -3014,6 +3038,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
         if (useQQVVQQany){
           strplabel[4]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, useQQVVQQany);
           strplabel[5]=TUtil::GetMCFMParticleLabel(pId[pZOrder[3]], false, useQQVVQQany);
+        }
+        else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+          strplabel[4]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+          strplabel[5]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
         }
         // End special Z2->nn cases
       }
@@ -3032,6 +3060,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
           if (useQQVVQQany){
             strplabel[4]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, useQQVVQQany);
             strplabel[5]=TUtil::GetMCFMParticleLabel(pId[pZOrder[3]], false, useQQVVQQany);
+          }
+          else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+            strplabel[4]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+            strplabel[5]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
           }
         }
         else{
@@ -3059,6 +3091,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
             strplabel[4]="qj";
             strplabel[5]="qj";
           }
+          else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+            strplabel[4]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+            strplabel[5]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+          }
         }
         if (!useQQVVQQany){ // colfac34_56 handles all couplings instead of this simple scaling (Reason: WW Final states)
           zcouple_.l2 *= sqrt(3.);
@@ -3070,6 +3106,10 @@ bool TUtil::MCFM_SetupParticleCouplings(
     else if (useQQVVQQany){
       strplabel[4]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, useQQVVQQany);
       strplabel[5]=TUtil::GetMCFMParticleLabel(pId[pZOrder[3]], false, useQQVVQQany);
+    }
+    else if (anomzffcouplings_.AllowAnomalousZffCouplings == 1){
+      strplabel[4]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
+      strplabel[5]=TUtil::GetMCFMParticleLabel(pId[pZOrder[2]], false, false);
     }
 
   } // End check WW, ZZ, ZG etc.
@@ -3999,6 +4039,39 @@ void TUtil::SetMCFMaTQGCCouplings(bool useBSM, aTQGCCouplings const* couplings){
       spinzerohiggs_anomcoupl_.dZAWpWm[im] = (couplings->aTQGCcoupl)[gATQGC_dZAWpWm][im];
       spinzerohiggs_anomcoupl_.dZZWpWm[im] = (couplings->aTQGCcoupl)[gATQGC_dZZWpWm][im];
     }
+  }
+}
+void TUtil::SetMCFMAZffCouplings(bool useBSM, AZffCouplings const* Zcouplings){
+  if (useBSM) {
+  // BSM (all imaginary parts = 0 => unset, only setting the real parts)
+    anomzffcouplings_.AllowAnomalousZffCouplings = 1;
+    anomzffcouplings_.reZ = (Zcouplings->AZffcoupl)[gZllRH][0];
+    anomzffcouplings_.leZ = (Zcouplings->AZffcoupl)[gZllLH][0];
+    anomzffcouplings_.rquZ = (Zcouplings->AZffcoupl)[gZuuRH][0];
+    anomzffcouplings_.lquZ = (Zcouplings->AZffcoupl)[gZuuLH][0];
+    anomzffcouplings_.rqdZ = (Zcouplings->AZffcoupl)[gZddRH][0];
+    anomzffcouplings_.lqdZ = (Zcouplings->AZffcoupl)[gZddLH][0];
+    anomzffcouplings_.rnZ = (Zcouplings->AZffcoupl)[gZnunuRH][0];
+    anomzffcouplings_.lnZ = (Zcouplings->AZffcoupl)[gZnunuLH][0];
+    anomzffcouplings_.clanou = (Zcouplings->AZffcoupl)[guZLH][0];
+    anomzffcouplings_.cranou = (Zcouplings->AZffcoupl)[guZRH][0];
+    anomzffcouplings_.clanod = (Zcouplings->AZffcoupl)[gdZLH][0];
+    anomzffcouplings_.cranod = (Zcouplings->AZffcoupl)[gdZRH][0];
+  } else {
+  // SM
+    anomzffcouplings_.AllowAnomalousZffCouplings = 0;
+    anomzffcouplings_.reZ = 0;
+    anomzffcouplings_.leZ = 0;
+    anomzffcouplings_.rquZ = 0;
+    anomzffcouplings_.lquZ = 0;
+    anomzffcouplings_.rqdZ = 0;
+    anomzffcouplings_.lqdZ = 0;
+    anomzffcouplings_.rnZ = 0;
+    anomzffcouplings_.lnZ = 0;
+    anomzffcouplings_.clanou = 0;
+    anomzffcouplings_.cranou = 0;
+    anomzffcouplings_.clanod = 0;
+    anomzffcouplings_.cranod = 0;
   }
 }
 void TUtil::SetJHUGenSpinZeroVVCouplings(double Hvvcoupl[SIZE_HVV][2], double Hvvpcoupl[SIZE_HVV][2], double Hvpvpcoupl[SIZE_HVV][2], int Hvvcoupl_cqsq[SIZE_HVV_CQSQ], double HvvLambda_qsq[SIZE_HVV_LAMBDAQSQ][SIZE_HVV_CQSQ], bool useWWcoupl){

--- a/MELA/src/ZZMatrixElement.cc
+++ b/MELA/src/ZZMatrixElement.cc
@@ -51,6 +51,7 @@ void ZZMatrixElement::build(){
   selfD_SpinTwoCouplings = Xcal2.GetSelfDSpinTwoCouplings();
   selfD_VprimeCouplings = Xcal2.GetSelfDVprimeCouplings();
   selfD_aTQGCCouplings = Xcal2.GetSelfDaTQGCCouplings();
+  selfD_AZffCouplings = Xcal2.GetSelfDAZffCouplings();
 
   if (processVerbosity>=TVar::DEBUG) MELAout << "End ZZMatrixElement::build" << endl;
 }
@@ -330,6 +331,13 @@ void ZZMatrixElement::set_aTQGCCouplings(
   double selfDaTQGCcoupl[SIZE_ATQGC][2]
 ){
   for (int ic=0; ic<SIZE_ATQGC; ic++) selfD_aTQGCCouplings->SetATQGCCouplings(ic, selfDaTQGCcoupl[ic][0], selfDaTQGCcoupl[ic][1]);
+}
+void ZZMatrixElement::set_AZffCouplings(
+  double selfDAZffcoupl[SIZE_AZff][2]
+){
+  for (int ic=0; ic<SIZE_AZff; ic++) {
+    selfD_AZffCouplings->SetAZffCouplings(ic, selfDAZffcoupl[ic][0], selfDAZffcoupl[ic][1]);
+  }
 }
 
 


### PR DESCRIPTION
Added an interface that enables parsing anomalous Zff couplings to MCFM through MELA. The current PR only includes the necessary C infrastructure and does _not_ explicitly update the python Mela() object. All python updates relevant to the interface are scheduled for a separate PR.