### PR TITLE
Creating the ability to change the Z Mass in JHUGenMELA

### DIFF
--- a/MELA/fortran/mod_JHUGenMELA.F90
+++ b/MELA/fortran/mod_JHUGenMELA.F90
@@ -11,6 +11,7 @@ MODULE ModJHUGenMELA
 
 public :: SetEWParameters
 public :: SetHiggsMassWidth
+public :: SetZMassWidth
 public :: SetDecayModes
 public :: SetTopDecays
 public :: SetHDK
@@ -56,6 +57,15 @@ subroutine SetHiggsMassWidth(mass,width)
    call SetDecayWidth(width,Hig_)
    return
 end subroutine SetHiggsMassWidth
+
+subroutine SetZMassWidth(mass,width)
+   implicit none
+   real(8), intent(in) :: mass, width
+   call SetMass(mass,Z0_)
+   call SetDecayWidth(width,Z0_)
+   PRINT *, M_Z
+   return
+end subroutine SetZMassWidth
 
 subroutine SetDecayModes(idfirst,idsecond)
    implicit none

--- a/MELA/interface/TModJHUGenMELA.hh
+++ b/MELA/interface/TModJHUGenMELA.hh
@@ -12,6 +12,7 @@ extern "C" {
   void __modjhugenmela_MOD_setdistinguishwwcouplingsflag(int* doallow); // YES, THE ARGUMENT IS AN INT, NOT A BOOL!
   void __modjhugenmela_MOD_sethdk(int* flag);
   void __modjhugenmela_MOD_sethiggsmasswidth(double *mass, double *width);
+  void __modjhugenmela_MOD_setzmasswidth(double *mass, double *width);
   void __modjhugenmela_MOD_setmurenfac(double* muren, double* mufac);
   void __modjhugenmela_MOD_resetmubarhgabarh();
   void __modjhugenmela_MOD_resetamplitudeincludes();

--- a/MELA/interface/TUtil.hh
+++ b/MELA/interface/TUtil.hh
@@ -229,6 +229,7 @@ namespace TUtil{
   // JHUGen-specific wrappers
   void InitJHUGenMELA(const char* pathtoPDFSet, int PDFMember, double collider_sqrts);
   void SetJHUGenHiggsMassWidth(double MReso, double GaReso);
+  void SetJHUGenZMassWidth(double MZ, double GaZ);
   void SetJHUGenDistinguishWWCouplings(bool doAllow);
   void ResetAmplitudeIncludes();
 

--- a/MELA/src/TUtil.cc
+++ b/MELA/src/TUtil.cc
@@ -3350,6 +3350,12 @@ void TUtil::SetJHUGenHiggsMassWidth(double MReso, double GaReso){
   GaReso *= GeV; // GeV units in JHUGen
   __modjhugenmela_MOD_sethiggsmasswidth(&MReso, &GaReso);
 }
+void TUtil::SetJHUGenZMassWidth(double MZ, double GaZ){
+  const double GeV = 1./100.;
+  MZ *= GeV; // GeV units in JHUGen
+  GaZ *= GeV; // GeV units in JHUGen
+  __modjhugenmela_MOD_setzmasswidth(&MZ, &GaZ);
+}
 void TUtil::SetJHUGenDistinguishWWCouplings(bool doAllow){
   int iAllow = (doAllow ? 1 : 0);
   __modjhugenmela_MOD_setdistinguishwwcouplingsflag(&iAllow);


### PR DESCRIPTION
Currently, the Z Mass can be changed in JHUGenerator but not in JHUGenMELA (without hardcoding). This push seeks to let you be able to do so via the function TUtil::SetJHUGenZMassWidth(MZ, GaZ), which is modelled after the near identical function TUtil::SetJHUGenHiggsMassWidth(MReso, GaReso).

The functionality from the SetMass and SetDecayWidth functions in the FORTRAN has not been changed - simply ported to the interface _should_ someone desire to change the Z Mass.