### PR TITLE
Updating ResonancePropagatorScheme in TVar.hh

### DIFF
--- a/MELA/interface/TVar.hh
+++ b/MELA/interface/TVar.hh
@@ -118,7 +118,8 @@ namespace TVar{
     NoPropagator=0,
     RunningWidth=1,
     FixedWidth=2,
-    CPS=3
+    CPS=3,
+    altRunningWidth=4
   };
 
   enum Process{


### PR DESCRIPTION
Added the altRunningWidth=4 to match previously accepted changes made to ResonancePropagatorScheme