### PR TITLE
Grab Bag of Fixes

### DIFF
--- a/MELA/data/el9_amd64_gcc12/download.url
+++ b/MELA/data/el9_amd64_gcc12/download.url
@@ -1,0 +1,1 @@
+http://spin.pha.jhu.edu/Generator/MCFM-precompiled/v9_12/

--- a/MELA/interface/TVar.hh
+++ b/MELA/interface/TVar.hh
@@ -26,7 +26,7 @@ typedef std::vector<SimpleParticle_t> SimpleParticleCollection_t;
 
 
 namespace TVar{
-  enum{
+  enum KAssociated{
     kNoAssociated=1,
     kUseAssociated_Leptons=2, // l or nu
     kUseAssociated_Photons=3,

--- a/MELA/interface/TVar.hh
+++ b/MELA/interface/TVar.hh
@@ -26,7 +26,7 @@ typedef std::vector<SimpleParticle_t> SimpleParticleCollection_t;
 
 
 namespace TVar{
-  enum KAssociated{
+  enum{
     kNoAssociated=1,
     kUseAssociated_Leptons=2, // l or nu
     kUseAssociated_Photons=3,

--- a/MELA/makefile
+++ b/MELA/makefile
@@ -86,7 +86,7 @@ $(LIBRULE):	$(OBJECTS) $(MELAOBJDIR)/LinkDef_out.o | alldirs
 	echo "Linking $(LIB)"; \
 	$(LINKER) $(LINKERFLAGS) -shared $(OBJECTS) $(MELAOBJDIR)/LinkDef_out.o -o $@
 
-$(pyLIBRULE): $(pyLINKFILE) | alldirs
+$(pyLIBRULE): $(pyLINKFILE) $(OBJECTS) $(MELAOBJDIR)/LinkDef_out.o | $(LIBRULE)
 	@echo "Making python"; \
 	$(LINKER) $(pyLINKFILE) $(CPPFLAGS) $(LINKERFLAGS) \
 	-O3 -Wall -shared $(OBJECTS) $(MELAOBJDIR)/LinkDef_out.o -std=c++17 -fPIC \

--- a/MELA/python/mela_binding.cpp
+++ b/MELA/python/mela_binding.cpp
@@ -218,13 +218,13 @@ SimpleParticleCollection_t collection_initializer(py::list listOfParticles){
 }
 
 void setInputEvent(Mela& mela, SimpleParticleCollection_t* daughters, SimpleParticleCollection_t* associated, SimpleParticleCollection_t* mothers, bool isgen){
-    if(daughters->size() == 0){
+    if((daughters) && (daughters->size() == 0)){
         daughters = 0;
     }
-    if (associated->size() == 0){
+    if ((associated) && (associated->size() == 0)){
         associated = 0;
     }
-    if (mothers->size() == 0){
+    if ((mothers) && (mothers->size() == 0)){
         mothers = 0;
     }
     mela.setInputEvent(daughters, associated, mothers, isgen);

--- a/MELA/python/mela_binding.cpp
+++ b/MELA/python/mela_binding.cpp
@@ -331,7 +331,7 @@ PYBIND11_MODULE(Mela, m) {
             return py::make_tuple(P.second.Pt(), P.second.Eta(), P.second.Phi(), P.second.M());
         })
         .def("__repr__",[](SimpleParticle_t& P){
-            return std::to_string(P.first) + ": " + std::to_string(P.second.Px()) + ", " + std::to_string(P.second.Py()) + ", " + std::to_string(P.second.Pz()) + ", " + std::to_string(P.second.E());
+            return std::to_string(P.first) + ": <" + std::to_string(P.second.Px()) + ", " + std::to_string(P.second.Py()) + ", " + std::to_string(P.second.Pz()) + ", " + std::to_string(P.second.E()) + ">";
         });
 
 

--- a/MELA/setup.sh
+++ b/MELA/setup.sh
@@ -16,6 +16,8 @@ getMELAARCH(){
     echo slc7_amd64_gcc820
   elif [[ "$GCCVERSION" == "8"* ]]; then
     echo slc7_amd64_gcc830
+  elif [[ "$GCCVERSION" == "12"* ]]; then
+    echo el9_amd64_gcc12
   else
   #elif [[ "$GCCVERSION" == "9"* ]]; then
     echo slc7_amd64_gcc920


### PR DESCRIPTION
There are a few portions to this PR:

## The following changes have been made to the Python binding
- As stated by @usarica during the offshell workshop, the 0 has a special place in `Mela::setInputEvent`. As such, the function has been turned into a wrapper which then provides a 0 to the input function if given an empty simpleParticleCollection
- The function TUtil::PrintCandidateSummary (whose implentation closes #49) , which has 2 possible inputs, has been split into 2
  - PrintCandidateSummary is now the one that takes in a simple event record
  - PrintCurrentCandidateSummary takes the current MELA candidate and prints it out
- SimpleParticle_t has some QoL edits
  - Since TLorentzVectors are near impossible to convert using Pybind (PyROOT TLorentzVectors cannot be passed in as the same object in pybind11 due to PyROOT's implementation), methods for returning the vector of a SimpleParticle_t in <Pt, Eta, Phi, M> and <Px, Py, Pz, E> as tuples have been implemented
  - A `__repr__` function was added for easier debugging
- SimpleParticleCollection_t has pickling support included. This is to allow for data processing before any MELA call and for usage within the [MultiProcessing](https://docs.python.org/3/library/multiprocessing.html) package
- cleanLinkedFiles as well as calculate4Momentum have been added as functions that can be called from the Python
- Every Enum in TVar.hh is now reflected in the Python

## The following changes have been made to TVar.hh
- The previously unnamed enum was named to KAssociated to allow for binding to the Python

## The following changes have been made to setup.sh and the data folder
- el9 gcc12 support has been added (I have found out that this was the cause of the errors from the workshop - the gcc version for CMSSW 14 on el9 was missing for MCFM)
- See the updated download.url in the folder