### PR TITLE
Make env setup not rely on PyBind installation

### DIFF
--- a/MELA/setup.sh
+++ b/MELA/setup.sh
@@ -49,6 +49,7 @@ for farg in "$@"; do
   if [[ "$fargl" == "deps" ]]; then
     doDeps=1
   elif [[ "$fargl" == "env" ]]; then
+    IgnorePyBind=TRUE
     doPrintEnv=1
   elif [[ "$fargl" == "envinstr" ]]; then
     doPrintEnvInstr=1


### PR DESCRIPTION
Change setup file so that setup does not depend on specific python libraries being installed. 