### PR TITLE
information/version control for .so

### DIFF
--- a/MELA/makefile
+++ b/MELA/makefile
@@ -43,7 +43,7 @@ ROOTINC = $(ROOFITINC)
 
 CC = g++
 CPPINC = -I$(MELADIR)/interface $(ROOTINC)
-CPPLOAD = -L$(MELALIBDIR) -lmcfm_710 -ljhugenmela -lcollier -lSMEFTsim $(LIBS)
+CPPLOAD = -L$(MELALIBDIR) -lmcfm_710 -ljhugenmela -lcollier -lMG_SMEFTsim_v1 $(LIBS)
 CPPOPTS =  -fPIC -O2 -ftree-vectorize -fipa-pta -felide-constructors -fvisibility-inlines-hidden -fno-math-errno \
 	--param vect-max-version-for-alias-checks=50 -fmessage-length=0 -fdiagnostics-show-option \
 	-Werror=unused-value -g \

--- a/MELA/src/Mela.cc
+++ b/MELA/src/Mela.cc
@@ -275,6 +275,34 @@ void Mela::printLogo() const{
     iline++;
   }
   MELAout.writeCentered("", '*', maxlinesize+10); MELAout << endl;
+
+  logolines.clear();
+  logolines.push_back("MadGraph5_aMC@NLO");
+  logolines.push_back("");
+  logolines.push_back("Going Beyond");
+  logolines.push_back("");
+  logolines.push_back("http://madgraph.hep.uiuc.edu");
+  logolines.push_back("http://madgraph.phys.ucl.ac.be");
+  logolines.push_back("http://amcatnlo.cern.ch");
+  logolines.push_back("");
+  logolines.push_back("The MadGraph5_aMC@NLO team");
+  logolines.push_back("");
+  logolines.push_back("Utilizing the SMEFTsim Package");
+  logolines.push_back("I. Brivio, Y. Jiang, M. Trott, arXiv: 1709.06492");
+  logolines.push_back("I. Brivio, arXiv: 2012.11343");
+  logolines.push_back("");
+  maxlinesize = 0;
+  for (auto const& l:logolines) maxlinesize = std::max(maxlinesize, l.length());
+  MELAout.writeCentered("", '*', maxlinesize+10); MELAout << endl;
+  iline=0;
+  for (auto const& l:logolines){
+    MELAout << '*';
+    MELAout.writeCentered(l, ' ', maxlinesize+8);
+    MELAout << '*' << endl;
+    if (iline==0){ MELAout.writeCentered("", '*', maxlinesize+10); MELAout << endl; }
+    iline++;
+  }
+  MELAout.writeCentered("", '*', maxlinesize+10); MELAout << endl;
 }
 
 // Set-functions


### PR DESCRIPTION
For the sake of consistency with MCFM, this PR changes add a formal writeout box for Madgraph, as well as changes the name of the library to include the MG name, as well as a version number.

The new Madgraph banner looks as such:
![image](https://github.com/JHUGen/JHUGenMELA/assets/15961349/77b31a20-40d4-40b5-a73b-52f5c3b50f85)
